### PR TITLE
Exporting the value accessor directive from the forms barrel, and adding an annotation to allow use with the closure compiler.

### DIFF
--- a/forms.ts
+++ b/forms.ts
@@ -1,1 +1,2 @@
 export { RecaptchaFormsModule } from './recaptcha/recaptcha-forms.module';
+export { RecaptchaValueAccessorDirective } from './recaptcha/recaptcha-value-accessor.directive';

--- a/recaptcha/recaptcha-loader.service.ts
+++ b/recaptcha/recaptcha-loader.service.ts
@@ -11,7 +11,10 @@ export const RECAPTCHA_LANGUAGE = new OpaqueToken('recaptcha-language');
 
 @Injectable()
 export class RecaptchaLoaderService {
-  /** @internal */
+  /**
+   * @internal
+   * @nocollapse
+   */
   private static ready: BehaviorSubject<ReCaptchaV2.ReCaptcha>;
 
   public ready: Observable<ReCaptchaV2.ReCaptcha>;


### PR DESCRIPTION
The RecaptchaValueAccessorDirective export was missing from the forms.ts barrel, so I added it back in.

Also, added a @nocollapse annotation which is required by the closure compiler to work with static fields.