### PR TITLE
Fix AOT error "Expression form not supported"

### DIFF
--- a/recaptcha/recaptcha-loader.service.ts
+++ b/recaptcha/recaptcha-loader.service.ts
@@ -26,7 +26,8 @@ export class RecaptchaLoaderService {
   private language: string;
 
   constructor(
-    @Inject(PLATFORM_ID) private readonly platformId: {},
+    // tslint:disable-next-line:no-any
+    @Inject(PLATFORM_ID) private readonly platformId: any,
     @Optional() @Inject(RECAPTCHA_LANGUAGE) language?: string,
   ) {
     this.language = language;


### PR DESCRIPTION

Fixes issues: #65 and #57 

I dug into the code and saw the issue is on this line:
https://github.com/DethAriel/ng-recaptcha/blob/master/recaptcha/recaptcha-loader.service.ts#L29
`@Inject(PLATFORM_ID) private readonly platformId: {}`

If I changed the empty type to `any` the error would go away. I did some searching and found a relevant issue for this behavior in the angular project.

**The compiler would throw this error for any @Inject with an interface type:**
https://github.com/angular/angular/issues/12631

The fix exists in Angular 4.2.0:
https://github.com/angular/angular/issues/15424#issuecomment-312116735

I've bumped the angular version to 4.2.0 and no longer see the error in the metadata after running `npm run transpile`