### PR TITLE
fix: #160 force a return type from functions called in constructor

### DIFF
--- a/recaptcha/recaptcha-loader.service.ts
+++ b/recaptcha/recaptcha-loader.service.ts
@@ -69,20 +69,22 @@ export class RecaptchaLoaderService {
     this.language = language;
     this.baseUrl = baseUrl;
     this.nonce = nonce;
-    this.init();
-    this.ready = isPlatformBrowser(this.platformId) ? RecaptchaLoaderService.ready.asObservable() : of();
+    const ready = this.initReady();
+    this.ready = ready ? ready.asObservable() : of();
   }
 
   /** @internal */
-  private init() {
+  private initReady(): BehaviorSubject<ReCaptchaV2.ReCaptcha> {
     if (RecaptchaLoaderService.ready) {
-      return;
+      return RecaptchaLoaderService.ready;
     }
     if (isPlatformBrowser(this.platformId)) {
       const subject = new BehaviorSubject<ReCaptchaV2.ReCaptcha>(null);
       RecaptchaLoaderService.ready = subject;
       const langParam = this.language ? '&hl=' + this.language : '';
       loadScript('explicit', (grecaptcha) => subject.next(grecaptcha), langParam, this.baseUrl, this.nonce);
+      return subject;
     }
+    return null;
   }
 }

--- a/recaptcha/recaptcha-v3.service.ts
+++ b/recaptcha/recaptcha-v3.service.ts
@@ -61,7 +61,7 @@ export class ReCaptchaV3Service {
     this.nonce = nonce;
     this.baseUrl = baseUrl;
 
-    this.init();
+    this.grecaptcha = this.initGrecaptcha();
   }
 
   public get onExecute(): Observable<OnExecuteData> {
@@ -122,14 +122,15 @@ export class ReCaptchaV3Service {
   }
 
   /** @internal */
-  private init() {
+  private initGrecaptcha(): ReCaptchaV2.ReCaptcha {
     if (this.isBrowser) {
       if ('grecaptcha' in window) {
-        this.grecaptcha = grecaptcha;
+        return grecaptcha;
       } else {
         loadScript(this.siteKey, this.onLoadComplete, '', this.baseUrl, this.nonce);
       }
     }
+    return null;
   }
 
   /** @internal */


### PR DESCRIPTION
Angular 7's buildOptimizer strips out the calls to methods with no return value when they are called in a constructor. I'm not 100% sure why this is. It's probably a bug in Terser. This PR works around the problem by always returning a type, thereby ensuring the function calls are preserved in each constructor.