### PR TITLE
fix(component): correct type when using strict mode

### DIFF
--- a/src/recaptcha/recaptcha.component.ts
+++ b/src/recaptcha/recaptcha.component.ts
@@ -19,8 +19,10 @@ import { RECAPTCHA_SETTINGS } from "./tokens";
 
 let nextId = 0;
 
+export type NeverUndefined<T> = T extends undefined ? never : T;
+
 export type RecaptchaErrorParameters = Parameters<
-  ReCaptchaV2.Parameters["error-callback"]
+  NeverUndefined<ReCaptchaV2.Parameters["error-callback"]>
 >;
 
 @Component({


### PR DESCRIPTION
When an application that depends on ng-recaptcha has tsconfig.json

    "strictNullChecks": true

the `Parameters<T>` utility type fails if the type parameter allows `undefined`.

Closes #211