### PR TITLE
Support for Angular-Localize

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,15 @@ import { RECAPTCHA_LANGUAGE } from "ng-recaptcha";
 export class MyModule {}
 ```
 
+In order to use the official angular-localize value as the recaptcha language:
+```typescript
+    {
+      provide: RECAPTCHA_LANGUAGE,
+      useFactory: (locale: string) => locale,
+      deps: [LOCALE_ID]
+    }
+```
+
 You can find the list of supported languages in [reCAPTCHA docs](https://developers.google.com/recaptcha/docs/language).
 
 ### <a name="example-error-handling"></a>Handling errors


### PR DESCRIPTION
When using the official angular localize package there is a problem that the recaptcha uses the browser language altrough the user specified that he wants to use a specific language from the dropdown (angular localize LOCALE_ID).

The following change take the LOCALE from angular localize and sets the recaptcha language to match the application language / user selected language. By default angular localize will use the browsers language so it's still correct.

https://angular.io/guide/i18n