### PR TITLE
fixes bug where recaptcha/api.js could not access CSP nonce

### DIFF
--- a/projects/ng-recaptcha/src/lib/load-script.ts
+++ b/projects/ng-recaptcha/src/lib/load-script.ts
@@ -20,7 +20,7 @@ function loadScript(
 
   script.src = `${baseUrl}?render=${renderMode}&onload=ng2recaptchaloaded${urlParams}`;
   if (nonce) {
-    script.nonce = nonce;
+    script.setAttribute('nonce', nonce);
   }
   script.async = true;
   script.defer = true;


### PR DESCRIPTION
`https://google.com/recaptcha/api.js` figures out the CSP nonce to use by checking a nonce attribute: `d.querySelector('script[nonce]')`. That does not work because this lib sets the nonce using `script.nonce = nonce`. This patch sets the nonce attribute instead, making `ng-recatpcha`'s `RECAPTCHA_NONCE` more useful.