### PR TITLE
[draft] ONLY-RESET: Only reset if there's a need to

### DIFF
--- a/projects/ng-recaptcha/src/lib/recaptcha.component.ts
+++ b/projects/ng-recaptcha/src/lib/recaptcha.component.ts
@@ -109,14 +109,11 @@ export class RecaptchaComponent implements AfterViewInit, OnDestroy {
   }
 
   public reset(): void {
-    if (this.widget != null) {
-      if (this.grecaptcha.getResponse(this.widget)) {
-        // Only emit an event in case if something would actually change.
-        // That way we do not trigger "touching" of the control if someone does a "reset"
-        // on a non-resolved captcha.
-        this.resolved.emit(null);
-      }
-
+    if (this.canResetRecaptcha()) {
+      // Only emit an event in case if something would actually change.
+      // That way we do not trigger "touching" of the control if someone does a "reset"
+      // on a non-resolved captcha.
+      this.resolved.emit(null);
       this.grecaptchaReset();
     }
   }
@@ -151,9 +148,13 @@ export class RecaptchaComponent implements AfterViewInit, OnDestroy {
 
   /** @internal */
   private grecaptchaReset() {
-    if (this.widget != null) {
+    if (this.canResetRecaptcha()) {
       this.zone.runOutsideAngular(() => this.grecaptcha.reset(this.widget));
     }
+  }
+
+  private canResetRecaptcha() {
+    return this.widget != null && this.grecaptcha.getResponse(this.widget);
   }
 
   /** @internal */


### PR DESCRIPTION
ng-recaptcha calls `reset()` in`onDestroy()`. This seems to be causing a JS error in console. Possibly, only resetting the recaptcha if it has data will resolve this. I'm experimenting using my fork; waiting for build to finish to test. The concept the PR is using doesn't seem to be helping.
~~I'm noticing now an `errorMode`, maybe that will also remove the JS error?~~

```quote
Unhandled Promise rejection: Timeout ; Zone: <root> ; Task: Promise.then ; Value: Timeout undefined
api.onUnhandledError @ zone.js:1061
handleUnhandledRejection @ zone.js:1086
api.microtaskDrainDone @ zone.js:1080
drainMicroTaskQueue @ zone.js:592
invokeTask @ zone.js:491
ZoneTask.invoke @ zone.js:476
data.args.<computed> @ zone.js:2385
setTimeout (async)
scheduleTask @ zone.js:2387
scheduleTask @ zone.js:393
scheduleTask @ zone.js:221
scheduleMacroTask @ zone.js:244
scheduleMacroTaskWithCurrentZone @ zone.js:683
(anonymous) @ zone.js:2429
proto.<computed> @ zone.js:973
(anonymous) @ recaptcha__en.js:294
(anonymous) @ recaptcha__en.js:251
ZoneAwarePromise @ zone.js:1429
(anonymous) @ recaptcha__en.js:250
(anonymous) @ recaptcha__en.js:109
(anonymous) @ recaptcha__en.js:110
invoke @ zone.js:372
run @ zone.js:134
(anonymous) @ zone.js:1275
invokeTask @ zone.js:406
runTask @ zone.js:178
drainMicroTaskQueue @ zone.js:585
invokeTask @ zone.js:491
ZoneTask.invoke @ zone.js:476
data.args.<computed> @ zone.js:2385
setTimeout (async)
scheduleTask @ zone.js:2387
scheduleTask @ zone.js:393
scheduleTask @ zone.js:221
scheduleMacroTask @ zone.js:244
scheduleMacroTaskWithCurrentZone @ zone.js:683
(anonymous) @ zone.js:2429
proto.<computed> @ zone.js:973
(anonymous) @ recaptcha__en.js:294
(anonymous) @ recaptcha__en.js:251
ZoneAwarePromise @ zone.js:1429
(anonymous) @ recaptcha__en.js:250
(anonymous) @ recaptcha__en.js:109
(anonymous) @ recaptcha__en.js:445
(anonymous) @ recaptcha__en.js:421
(anonymous) @ recaptcha__en.js:514
(anonymous) @ ng-recaptcha.mjs:179
invoke @ zone.js:372
run @ zone.js:134
runOutsideAngular @ core.mjs:26211
grecaptchaReset @ ng-recaptcha.mjs:179
ngOnDestroy @ ng-recaptcha.mjs:121
executeOnDestroys @ core.mjs:7551
cleanUpView @ core.mjs:7452
destroyViewTree @ core.mjs:7278
destroyLView @ core.mjs:7430
destroy @ core.mjs:21208
destroy @ core.mjs:21631
deactivate @ router.mjs:2308
deactivateRouteAndOutlet @ router.mjs:2692
deactivateRouteAndItsChildren @ router.mjs:2665
deactivateRouteAndOutlet @ router.mjs:2688
deactivateRouteAndItsChildren @ router.mjs:2665
deactivateRoutes @ router.mjs:2654
(anonymous) @ router.mjs:2626
deactivateChildRoutes @ router.mjs:2624
activate @ router.mjs:2616
(anonymous) @ router.mjs:2603
(anonymous) @ map.js:7
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
source.subscribe.isUnsub @ tap.js:18
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
(anonymous) @ map.js:7
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
subscribe.innerSubscriber @ switchMap.js:14
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
(anonymous) @ map.js:7
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
(anonymous) @ innerFrom.js:51
_trySubscribe @ Observable.js:37
(anonymous) @ Observable.js:31
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
(anonymous) @ map.js:6
(anonymous) @ lift.js:10
(anonymous) @ Observable.js:26
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
source.subscribe.isComplete @ switchMap.js:14
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
subscribe.innerSubscriber @ switchMap.js:14
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
(anonymous) @ map.js:7
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
(anonymous) @ take.js:12
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
(anonymous) @ defaultIfEmpty.js:11
OperatorSubscriber._complete @ OperatorSubscriber.js:36
complete @ Subscriber.js:49
(anonymous) @ innerFrom.js:53
_trySubscribe @ Observable.js:37
(anonymous) @ Observable.js:31
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
(anonymous) @ defaultIfEmpty.js:6
(anonymous) @ lift.js:10
(anonymous) @ Observable.js:26
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
(anonymous) @ take.js:10
(anonymous) @ lift.js:10
(anonymous) @ Observable.js:26
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
(anonymous) @ map.js:6
(anonymous) @ lift.js:10
(anonymous) @ Observable.js:26
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
source.subscribe.isComplete @ switchMap.js:14
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
subscribe.innerSubscriber @ switchMap.js:14
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
(anonymous) @ map.js:7
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
source.subscribe.isUnsub @ tap.js:18
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
subscribe.innerSubscriber @ switchMap.js:14
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
source.subscribe.isUnsub @ tap.js:18
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
subscribe.innerComplete @ mergeInternals.js:25
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
subscribe.innerComplete @ mergeInternals.js:25
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
(anonymous) @ innerFrom.js:51
_trySubscribe @ Observable.js:37
(anonymous) @ Observable.js:31
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
doInnerSub @ mergeInternals.js:19
outerNext @ mergeInternals.js:14
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
source.subscribe.buffer @ takeLast.js:14
OperatorSubscriber._complete @ OperatorSubscriber.js:36
complete @ Subscriber.js:49
source.subscribe.isUnsub @ tap.js:23
OperatorSubscriber._complete @ OperatorSubscriber.js:36
complete @ Subscriber.js:49
checkComplete @ mergeInternals.js:11
(anonymous) @ mergeInternals.js:52
OperatorSubscriber._complete @ OperatorSubscriber.js:36
complete @ Subscriber.js:49
(anonymous) @ innerFrom.js:53
_trySubscribe @ Observable.js:37
(anonymous) @ Observable.js:31
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
mergeInternals @ mergeInternals.js:50
(anonymous) @ mergeMap.js:13
(anonymous) @ lift.js:10
(anonymous) @ Observable.js:26
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
(anonymous) @ tap.js:15
(anonymous) @ lift.js:10
(anonymous) @ Observable.js:26
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
(anonymous) @ takeLast.js:9
(anonymous) @ lift.js:10
(anonymous) @ Observable.js:26
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
mergeInternals @ mergeInternals.js:50
(anonymous) @ mergeMap.js:13
(anonymous) @ lift.js:10
(anonymous) @ Observable.js:26
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
doInnerSub @ mergeInternals.js:19
outerNext @ mergeInternals.js:14
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
(anonymous) @ innerFrom.js:51
_trySubscribe @ Observable.js:37
(anonymous) @ Observable.js:31
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
mergeInternals @ mergeInternals.js:50
(anonymous) @ mergeMap.js:13
(anonymous) @ lift.js:10
(anonymous) @ Observable.js:26
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
(anonymous) @ tap.js:15
(anonymous) @ lift.js:10
(anonymous) @ Observable.js:26
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
source.subscribe.isComplete @ switchMap.js:14
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
source.subscribe.isUnsub @ tap.js:18
OperatorSubscriber._next @ OperatorSubscriber.js:13
next @ Subscriber.js:31
(anonymous) @ innerFrom.js:51
_trySubscribe @ Observable.js:37
(anonymous) @ Observable.js:31
errorContext @ errorContext.js:19
subscribe @ Observable.js:22
(anonymous) @ tap.js:15
(anonymous) @ lift.js:10
Promise.then (async)
nativeScheduleMicroTask @ zone.js:561
scheduleMicroTask @ zone.js:572
scheduleTask @ zone.js:396
onScheduleTask @ zone.js:283
scheduleTask @ zone.js:386
scheduleTask @ zone.js:221
scheduleMicroTask @ zone.js:241
scheduleResolveOrReject @ zone.js:1265
resolvePromise @ zone.js:1202
(anonymous) @ zone.js:1118
(anonymous) @ zone.js:1134
webpackJsonpCallback @ jsonp chunk loading:77
(anonymous) @ src_app_modules_content_content_module_ts.js:2
```